### PR TITLE
Profile Color Theme Routes and changes to User Model

### DIFF
--- a/api/profile.js
+++ b/api/profile.js
@@ -109,14 +109,9 @@ router.patch("/me", authenticateJWT, async (req, res) => {
     }
 
     if (profileTheme !== undefined) {
-      const validThemes = [
-        'default', 'ocean', 'sunset', 'purple', 'forest', 'rose',
-        'sakura', 'lavender', 'peach', 'mint', 'cotton', 'sky',
-        'shadow', 'crimson', 'neon', 'void', 'electric'
-      ];
-      
-      if (profileTheme && !validThemes.includes(profileTheme)) {
-        return res.status(400).json({ error: "Invalid theme selection" });
+      // allow any reasonable string
+      if (profileTheme && (typeof profileTheme !== 'string' || profileTheme.length > 50)) {
+        return res.status(400).json({ error: "Theme must be a string of 50 characters or less" });
       }
       updateData.profileTheme = profileTheme || 'default';
     }

--- a/database/user.js
+++ b/database/user.js
@@ -98,14 +98,13 @@ const User = db.define("user", {
     field: 'spotify_profile_image'
   },
   profileTheme: {
-    type: DataTypes.ENUM(
-      'default', 'ocean', 'sunset', 'purple', 'forest', 'rose',
-      'sakura', 'lavender', 'peach', 'mint', 'cotton', 'sky',
-      'shadow', 'crimson', 'neon', 'void', 'electric'
-    ),
+    type: DataTypes.STRING,
     allowNull: false,
     defaultValue: 'default',
-    field: 'profile_theme'
+    field: 'profile_theme',
+    validate: {
+      len: [1, 50] // Allow themes up to 50 characters
+    }
   },
 }, {
   tableName: 'users',


### PR DESCRIPTION
• Database: Added [profileTheme] STRING field to User model

• API Endpoints:
Theme Loading: GET /api/profile/me → Gets full profile including [profileTheme]
Theme Saving: PATCH /api/profile/me → Updates profile including [profileTheme]
Public Themes: GET /api/profile/{username} → Gets public profile including [profileTheme]

• Backend Fixes: Resolved Sequelize validation conflicts by adding [validate: false] for profile updates
## RUN `npm run seed` after merge