### PR TITLE
Analytics Routes

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -9,6 +9,7 @@ const stickersRouter = require("./stickers");
 const followRouter = require("./follow");
 const commentsRouter = require('./comments');
 
+
 router.use("/test-db", testDbRouter);
 router.use("/search-songs", searchRouter);
 router.use("/posts", postsRouter);


### PR DESCRIPTION


### `GET /auth/spotify/history`

Returns the authenticated user's Spotify listening history, top genres, and top artists by genre.  
Response includes:
- `recentTracks`: List of recently played tracks with details.
- `topGenres`: Array of genres ranked by frequency.
- `artistsByGenre`: Artists grouped and sorted