### PR TITLE
Fix 500 on /history and /ai-recommendations when an artist has no genres

### DIFF
--- a/auth/spotify.js
+++ b/auth/spotify.js
@@ -712,7 +712,7 @@ router.get(
       // Aggregate genres from top artists
       const genreCount = {};
       topArtists.forEach((artist) => {
-        artist.genres.forEach((genre) => {
+        (artist.genres || []).forEach((genre) => {
           genreCount[genre] = (genreCount[genre] || 0) + 1;
         });
       });
@@ -724,7 +724,7 @@ router.get(
       // Rank top artists by genre
       const artistsByGenre = {};
       topArtists.forEach((artist) => {
-        artist.genres.forEach((genre) => {
+        (artist.genres || []).forEach((genre) => {
           if (!artistsByGenre[genre]) artistsByGenre[genre] = [];
           artistsByGenre[genre].push({
             id: artist.id,
@@ -985,7 +985,7 @@ router.get(
         // Aggregate genres from top artists
         const genreCount = {};
         topArtists.forEach((artist) => {
-          artist.genres.forEach((genre) => {
+          (artist.genres || []).forEach((genre) => {
             genreCount[genre] = (genreCount[genre] || 0) + 1;
           });
         });


### PR DESCRIPTION
Spotify's top-artists response omits the genres field for some artists instead of returning an empty array. The code called artist.genres.forEach directly, so a single genre-less artist threw a TypeError, which the outer catch turned into a 500. That broke the entire Analytics dashboard, since both the listening-history and top-genres components read from /history.

Guard the access with (artist.genres || []) in all three aggregation spots.